### PR TITLE
niimpy/read: read_csv: Allow specifying pandas CSV reading options

### DIFF
--- a/niimpy/read.py
+++ b/niimpy/read.py
@@ -52,18 +52,24 @@ def read_sqlite_tables(filename):
 
 
 
-def read_csv(filename):
+def read_csv(filename, read_csv_options={}):
     """Read DataFrame from csv file
 
-        This will read data from a csv file.
+    This will read data from a csv file and then process the result with
+    `niimpy.util.df_normalize`.
 
-        Parameters
-        ----------
 
-        filename : str
-            filename of csv file
+    Parameters
+    ----------
+
+    filename : str
+        filename of csv file
+
+    read_csv_options: dict
+        Dictionary of options to pandas.read_csv, if this is necessary for custom
+        csv files.
     """
-    df = pd.read_csv(filename)
+    df = pd.read_csv(filename, **read_csv_options)
 
     # df_normalize converts sets the index to time values and does other time
     # conversions.  Inplace.


### PR DESCRIPTION
- Some custom CSV files may need special options to read.  This allows
  passing arbitrary pandas.read_csv options to the underlying reader.
- Review: general check