### PR TITLE
.github/workflows/test: Remove sqlite3 extension installation by default now

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,9 +20,11 @@ jobs:
       - name: install deps
         run: |
           pip install -r requirements.txt -r requirements-dev.txt
-      - name: setup extension
-        run: |
-          python -c 'import niimpy ; niimpy.util.install_extensions()'
+      # sqlite3 extension is no urgently needed anymore; no longer required
+      # by default
+      #- name: setup extension
+      #  run: |
+      #    python -c 'import niimpy ; niimpy.util.install_extensions()'
       - name: pytest
         run: |
           pytest


### PR DESCRIPTION
- This was used to optimize certain type of queries, but since we are
  not using the database much anymore, there is no point to test this.