### PR TITLE
screen_duration: upgrade to use DataFrames and add unit test

### DIFF
--- a/niimpy/__init__.py
+++ b/niimpy/__init__.py
@@ -1,7 +1,9 @@
 from ._version import __version__
 
 from .database import open, Data1, ALL
-from . import util
-from . import sampledata
+from .filter import filter_dataframe
+from . import preprocess
 from .read import read_sqlite, read_sqlite_tables
 from .read import read_csv
+from . import sampledata
+from . import util

--- a/niimpy/filter.py
+++ b/niimpy/filter.py
@@ -1,0 +1,43 @@
+"""Generic DataFrame filtering
+
+This module provides functions for generic DataFrame filtering.  In many
+cases, it is simpler to do these filtering operations yourself directly
+on the DataFrames, but these functions simplify the operations of
+standard arguments in other functions.
+"""
+
+
+def filter_dataframe(df, user=None, begin=None, end=None, rename_columns={}):
+    """Standard dataframe preprocessing filter.
+
+    This implements some standard and common dataframe preprocessing
+    options, which are used in very many functions.  It is likely
+    simpler and more clear to do these yourself on the DataFrames
+    directly.
+
+    - select only certain user: `df['user'] == user`
+    - select date range:  `df[begin:end]`
+    - column map: `df.rename(columns=rename_columns)`
+
+    It returns a new dataframe (and does not modify the passed one in-place).
+    """
+    if user:
+        df = df[df['user'] == user]
+    # Slice by time
+    time_slice = None
+    # begin and end
+    if begin is not None and end is not None:
+        time_slice = slice(begin, end)
+    # begin only
+    elif begin is not None:
+        time_slice = slice(begin, None)
+    # end only
+    elif end is not None:
+        time_slice = slice(None, end)
+    if time_slice is not None:
+        df = df.loc[time_slice]
+
+    if rename_columns:
+        df = df.rename(columns=rename_columns)
+
+    return df

--- a/niimpy/preprocess.py
+++ b/niimpy/preprocess.py
@@ -1290,7 +1290,10 @@ def screen_duration(screen,subject=None,begin=None,end=None,battery=None):
     screen = screen[~((screen.group==1) & (screen.duration>thr))]
 
     #Finally organize everything
-    duration=pd.pivot_table(screen,values='duration',index='datetime', columns='group', aggfunc=np.sum)
+    # Somehow aggfunc=np.sum fails and makes an empty DataFrame.  But
+    # passing it through a lambda indirection does work.  This is
+    # needed in pandas>=1.30.
+    duration=screen.pivot_table(values='duration',index='datetime', columns='group', aggfunc=lambda x: np.sum(x))
     #duration['total']=duration.sum(axis=1)
     #mean_hours=duration['total'].mean()
     #print('mean hours in record per day: ' + str(mean_hours))

--- a/niimpy/preprocess.py
+++ b/niimpy/preprocess.py
@@ -226,22 +226,10 @@ def shutdown_info(database,subject,begin=None,end=None):
     shutdown: Dataframe
 
     """
+    bat = niimpy.read._read_sqlite_auto(database, table='AwareBattery', user=subject)
+    bat = niimpy.filter_dataframe(bat, begin=begin, end=end)
 
-    assert isinstance(database, niimpy.database.Data1),"database not given in Niimpy database format"
-    assert isinstance(subject, str),"user not given in string format"
-
-    bat=database.raw(table='AwareBattery', user=subject)
-
-    if(begin!=None):
-        assert isinstance(begin,pd.Timestamp),"begin not given in timestamp format"
-    else:
-        begin = bat.iloc[0]['datetime']
-    if(end!= None):
-        assert isinstance(end,pd.Timestamp),"end not given in timestamp format"
-    else:
-        end = bat.iloc[len(bat)-1]['datetime']
-
-    bat = bat.drop(columns=['device','user','time','battery_health','battery_adaptor','battery_level'])
+    bat = bat[['battery_status', 'datetime']]
     bat=bat.loc[begin:end]
     bat['battery_status']=pd.to_numeric(bat['battery_status'])
     shutdown = bat[bat['battery_status'].between(-3, 0, inclusive=False)]

--- a/niimpy/read.py
+++ b/niimpy/read.py
@@ -50,6 +50,39 @@ def read_sqlite_tables(filename):
     db = database.Data1(filename)
     return db.tables()
 
+def _read_sqlite_auto(df_or_database, table, user=None):
+    """Read from database or directly use DataFrame
+
+    Functions used to accept a database only, now the standard is
+    dataframe.  This provides some backwards compatability between the
+    old and new systems: DataFrames are used as-is, but if a database is
+    given, it extracts the right information out of the table (and does
+    what the database used to do to filter by user).
+
+    A typical usage is::
+
+        def function(df):
+            # 'df' could be a DataFrame or database
+            df = _read_sqlite_auto(df, 'TableName')
+            # 'df' is now always a DataFrame
+
+    Returns
+    -------
+    df : DataFrame
+
+    """
+    if isinstance(df_or_database, database.Data1):
+        df = df_or_database.raw(table=table, user=subject)
+    else:
+        df = df_or_database
+        # Maintain backwards compatibility in the case subject was passed and
+        # questions was *not* a dataframe.
+        if isinstance(user, str):
+            df = df[df['user'] == user]
+    return df
+
+
+
 
 
 def read_csv(filename, read_csv_options={}):

--- a/niimpy/sampledata.py
+++ b/niimpy/sampledata.py
@@ -25,3 +25,9 @@ SURVEY_PHQ9 = os.path.join(_dirname, 'survey_phq9.csv')
 # Aware screen/battery for one month.
 SCREEN_MONTH = os.path.join(_dirname, 'AwareScreen_1month.csv.gz')
 BATTERY_MONTH = os.path.join(_dirname, 'AwareBattery_1month.csv.gz')
+
+
+# Data for tests
+
+TEST_SCREEN_1 = os.path.join(_dirname, 'test_screen_1.csv')
+TEST_BATTERY_1 = os.path.join(_dirname, 'test_battery_1.csv')

--- a/niimpy/sampledata/test_battery_1.csv
+++ b/niimpy/sampledata/test_battery_1.csv
@@ -1,0 +1,2 @@
+time,battery_level,battery_status
+0,100,3

--- a/niimpy/sampledata/test_screen_1.csv
+++ b/niimpy/sampledata/test_screen_1.csv
@@ -1,0 +1,5 @@
+time,screen_status
+0 ,1
+60,0
+600,1
+610,0

--- a/niimpy/test_filter.py
+++ b/niimpy/test_filter.py
@@ -1,0 +1,35 @@
+import io
+
+import numpy
+from pandas import Series
+
+import niimpy
+
+csv = io.StringIO(
+"""\
+user,time,value
+a,0,0
+a,100,1
+a,3700,2
+b,90000,3
+b,90001,4
+b,90002,5
+"""
+    )
+
+def test_filter_dataframe():
+    df = niimpy.read_csv(csv)
+    assert len(niimpy.filter_dataframe(df)) == 6
+
+    # User limits
+    assert len(niimpy.filter_dataframe(df, user='a')) == 3
+
+    # Time limits
+    assert len(niimpy.filter_dataframe(df, end='1970-01-01')) == 3
+    assert len(niimpy.filter_dataframe(df, begin='1970-01-02')) == 3
+    assert len(niimpy.filter_dataframe(df, begin='1970-01-01 02:01:00', end='1970-01-01')) == 2
+    df2 = niimpy.filter_dataframe(df, begin='1970-01-01 02:01:00', end='1970-01-01')
+    numpy.testing.assert_array_equal(df2['value'].values, [1,2])
+
+    # Renaming columns
+    assert 'new' in niimpy.filter_dataframe(df, rename_columns={'value': 'new'})

--- a/niimpy/test_screen.py
+++ b/niimpy/test_screen.py
@@ -1,0 +1,20 @@
+import pandas as pd
+from pandas import Timestamp
+
+import niimpy
+from niimpy.util import TZ
+
+def test_screen():
+    screen  = niimpy.read_csv(niimpy.sampledata.TEST_SCREEN_1)
+    battery = niimpy.read_csv(niimpy.sampledata.TEST_BATTERY_1)
+    duration, count = niimpy.preprocess.screen_duration(screen, battery=battery)
+    print('duration:')
+    print(duration)
+    print('count:')
+    print(count)
+    # On and off duration during this day
+    assert duration.loc[Timestamp('1970-01-01', tz=niimpy.util.TZ), 'on'] == 10
+    assert duration.loc[Timestamp('1970-01-01', tz=niimpy.util.TZ), 'off'] == 540
+    # on==1 for some reason
+    assert count.loc[Timestamp('1970-01-01', tz=niimpy.util.TZ), 'on_count'] == 1
+    assert count.loc[Timestamp('1970-01-01', tz=niimpy.util.TZ), 'off_count'] == 1


### PR DESCRIPTION
- The main point is to add unit tests before beginning a bigger rearrangement.  But to do that, it has to be tested first.
- This updates this function to accept dataframes
- As part of that, add filter.dataframe_filter and read._read_sqlite_auto which are backwards compatibility (and duplication reduction) functions
- Add a simple unit test
- But at the same time, shutdown_info has to be upgraded because it is also used for in screen_duration (and many other places).  all the above (except unit testing) is done here as well.