### PR TITLE
niimpy/preprocess: use index instead of merge datetime_x and datetime_y

### DIFF
--- a/niimpy/preprocess.py
+++ b/niimpy/preprocess.py
@@ -1216,9 +1216,7 @@ def screen_duration(screen,subject=None,begin=None,end=None,battery=None):
     screen = screen.merge(shutdown, how='outer', left_index=True, right_index=True)
     screen['screen_status'] = screen.fillna(0)['screen_status_x'] + screen.fillna(0)['screen_status_y']
     screen = screen.drop(['screen_status_x','screen_status_y'],axis=1)
-    dates=screen.datetime_x.combine_first(screen.datetime_y)
-    screen['datetime']=dates
-    screen = screen.drop(['datetime_x','datetime_y'],axis=1)
+    screen['datetime']=screen.index
 
     #Detect missing data points
     screen['missing']=0


### PR DESCRIPTION
- The datetime column should be the same as the index (one of the
  definitions of niimpy), and I aim to eliminate 'datetime' from
  standard usage (since it's a duplicate of the index).

- Remove the merging of the two datetime columns, and use the index,
  which should be the timestamps of every row when done with the outer
  join.  At least, index should always be the value of one of the
  datetimes, and if the datetime_{x,y} are the same then it should be
  the same as the index.

- This is more resilent if one of the dataframes is empty or not
  passed, or missing the `datetime` column.  This will be more common
  in the future since I will try to remove `datetime` wherever
  possible and suggest that only the index is used.

- I found that we *do* need a datetime column in the rest of the
  calculation, since (at least) .shift() and .diff() are not
  implemented on DatetimeIndex.  So we can't only use the rest of the
  index for the rest of the function.

- If this works I will go make other adjustments to remove unnecssary
  uses of datetime earlier in the function.

- Review: general check by someone that knows pandas