### PR TITLE
niimpy/preprocess: Solve some warnings in screen_duration

### DIFF
--- a/niimpy/preprocess.py
+++ b/niimpy/preprocess.py
@@ -1260,12 +1260,12 @@ def screen_duration(screen,subject=None,begin=None,end=None,battery=None):
     screen=screen.rename(columns={'missing':'group'})
     screen['next']=screen['screen_status'].shift(-1)
     screen['next']=screen['screen_status'].astype(int).astype(str)+screen['screen_status'].shift(-1).fillna(0).astype(int).astype(str)
-    screen.group[(screen.next=='01') | (screen.next=='02')]=1
-    screen.group[(screen.next=='03') | (screen.next=='13') | (screen.next=='23')]=2
-    screen.group[(screen.next=='12') | (screen.next=='21') | (screen.next=='31') | (screen.next=='32')]=3
+    screen.loc[(screen.next=='01') | (screen.next=='02'), 'group']=1
+    screen.loc[(screen.next=='03') | (screen.next=='13') | (screen.next=='23'), 'group']=2
+    screen.loc[(screen.next=='12') | (screen.next=='21') | (screen.next=='31') | (screen.next=='32'), 'group']=3
     del screen['next']
     screen['group'] = screen['group'].shift(1)
-    screen.loc[:1,'group']=0
+    screen.loc[screen.index[:1],'group']=0
     del screen['screen_status']
 
     '''


### PR DESCRIPTION
- These make unit tests cleaner, and I think these are the current
  "right" ways to do pandas indexing.
- The last one (`screen.loc[screen.index[:1],'group']=0`) was a bit
  harder because it combines position-based and label-based indexing.
  This solution I settled on semeed to be recommend on some random
  stack exchange answer.
- Review: general check, ensure that I am not missing something.