### PR TITLE
screen: remove some extra 'datetime' appearances

### DIFF
--- a/docs/screen.ipynb
+++ b/docs/screen.ipynb
@@ -196,28 +196,25 @@
        "    <tr style=\"text-align: right;\">\n",
        "      <th></th>\n",
        "      <th>screen_status</th>\n",
-       "      <th>datetime</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
        "      <th>1970-01-01 02:01:00+02:00</th>\n",
        "      <td>0.0</td>\n",
-       "      <td>1970-01-01 02:01:00+02:00</td>\n",
        "    </tr>\n",
        "    <tr>\n",
        "      <th>1970-01-01 03:01:00+02:00</th>\n",
        "      <td>0.0</td>\n",
-       "      <td>1970-01-01 03:01:00+02:00</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "                           screen_status                  datetime\n",
-       "1970-01-01 02:01:00+02:00            0.0 1970-01-01 02:01:00+02:00\n",
-       "1970-01-01 03:01:00+02:00            0.0 1970-01-01 03:01:00+02:00"
+       "                           screen_status\n",
+       "1970-01-01 02:01:00+02:00            0.0\n",
+       "1970-01-01 03:01:00+02:00            0.0"
       ]
      },
      "execution_count": 3,
@@ -295,11 +292,6 @@
        "      <th>off</th>\n",
        "      <th>on</th>\n",
        "    </tr>\n",
-       "    <tr>\n",
-       "      <th>datetime</th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
@@ -313,7 +305,6 @@
       ],
       "text/plain": [
        "group                       off  on\n",
-       "datetime                           \n",
        "1970-01-01 00:00:00+02:00  3540  60"
       ]
      },
@@ -355,11 +346,6 @@
        "      <th>off_count</th>\n",
        "      <th>on_count</th>\n",
        "    </tr>\n",
-       "    <tr>\n",
-       "      <th>datetime</th>\n",
-       "      <th></th>\n",
-       "      <th></th>\n",
-       "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
        "    <tr>\n",
@@ -373,7 +359,6 @@
       ],
       "text/plain": [
        "group                      off_count  on_count\n",
-       "datetime                                      \n",
        "1970-01-01 00:00:00+02:00          1         1"
       ]
      },
@@ -385,27 +370,13 @@
    "source": [
     "count"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Niimpy development",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "niimpy-dev"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -417,7 +388,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/niimpy/screen.py
+++ b/niimpy/screen.py
@@ -83,6 +83,7 @@ def screen_off(screen,subject=None,begin=None,end=None,battery=None):
     #Select only those OFF events
     screen = screen[screen.screen_status == 0]
     del screen['missing']
+    del screen['datetime']
     return screen
 
 
@@ -225,4 +226,7 @@ def screen_duration(screen,subject=None,begin=None,end=None,battery=None):
     duration = duration.apply(preprocess.get_seconds,axis=1)
     count=pd.pivot_table(screen,values='duration',index='datetime', columns='group', aggfunc='count')
     count.columns = count.columns.map({0.0: 'off_count', 1.0: 'on_count', 2.0: 'use_count', 3.0: 'irrelevant_count', 4.0: 'total_count'})
+    # reset index names
+    duration.index.name = None
+    count.index.name = None
     return duration, count


### PR DESCRIPTION
- remove a column that got leaked to the final output.
- remove 'datetime' name on index of screen_duration.