### PR TITLE
reading: add add_group= option to all reading functions

### DIFF
--- a/niimpy/test_read.py
+++ b/niimpy/test_read.py
@@ -1,0 +1,21 @@
+import pandas as pd
+import numpy as np
+
+import niimpy
+from . import read
+from . import sampledata
+
+
+def test_read_preprocess_add_group():
+    """Test of add_group= option"""
+    data = pd.DataFrame({'user': ['u1', 'u2', 'u3'], 'a': [1,2,3], 'b': [4,5,6]})
+    data2 = read._read_preprocess(data, add_group='group1')
+    assert 'group' in data2
+    assert (data2['group'] == 'group1').all()
+
+
+def test_read_preprocess_add_group_csv():
+    """Test of add_group= option"""
+    data = niimpy.read_csv(sampledata.DATA_CSV, add_group='group1')
+    assert 'group' in data
+    assert data['group'][0] == 'group1'


### PR DESCRIPTION
- This adds a new add_group option to all of the current reading
  functions.  It will add a new column 'group' to the dataframes once
  it is read.  This could be useful when reading and combining
  dataframes from different groups in different files.
- Pandas equivalent: `df['group'] = add_group`
  It is questionable if it is better to have this argument, or tell
  people how to run this.
- This is tested but not documented yet (for documentation I am
  interested in thinking a bit more about where it would go, this
  wouldn't be duplicated for each type).
- Review: general check, is this a good idea?