### PR TITLE
niimpy/read: Allow user to be any format (not just str)

### DIFF
--- a/niimpy/read.py
+++ b/niimpy/read.py
@@ -84,7 +84,7 @@ def _get_dataframe(df_or_database, table, user=None):
         df = df_or_database
         # Maintain backwards compatibility in the case subject was passed and
         # questions was *not* a dataframe.
-        if isinstance(user, str):
+        if user is not None and user is not database.ALL:
             df = df[df['user'] == user]
     return df
 


### PR DESCRIPTION
- Allow the user value to be any format, not just 'str'.  There is no
  reason to limit it, if it's not matching the error is obvious (not
  selecting the right user/empty results).  Existing error handling
  can manage this.
- Review: general check/think about it