### PR TITLE
niimpy/preprocessing/util: Clarify a timezone depreciation warning

### DIFF
--- a/niimpy/preprocessing/util.py
+++ b/niimpy/preprocessing/util.py
@@ -98,7 +98,7 @@ def df_normalize(df, tz=None, old_tz=None):
     to pandas.TimeStamp:s.  Modifies the data frame inplace.
     """
     if tz is None:
-        warnings.warn(DeprecationWarning("From now on, you should explicitely specify timezone with e.g. tz='Europe/Helsinki'"), stacklevel=2)
+        warnings.warn(DeprecationWarning("From now on, you should explicitely specify timezone with e.g. tz='Europe/Helsinki'.  Specify as part of the reading function."))
         tz = TZ
     if 'time' in df:
         df.index = to_datetime(df['time'])


### PR DESCRIPTION
- Provide a better message when timezone is not specified.
- This is an uncommited change from long ago (and may still need updating)
