### PR TITLE
Do not deploy to Github Pages

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -22,11 +22,11 @@ jobs:
         run: |
           cd docs
           make clean dirhtml #SPHINXOPTS='-W --keep-going'
-      - name: deploy
-        uses: peaceiris/actions-gh-pages@v3
-        if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
-        with:
-          publish_branch: gh-pages
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: docs/_build/dirhtml/
-          force_orphan: true
+      #- name: deploy
+      #  uses: peaceiris/actions-gh-pages@v3
+      #  if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
+      #  with:
+      #    publish_branch: gh-pages
+      #    github_token: ${{ secrets.GITHUB_TOKEN }}
+      #    publish_dir: docs/_build/dirhtml/
+      #    force_orphan: true


### PR DESCRIPTION
We deploy only via ReadTheDocs, having two places to deploy is bad.  Leave the rest of the test to test building the docs.