### PR TITLE
Remove python 3.6 from workflows

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - 3.6
+          - 3.8
           - 3.9
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - 3.6
           - 3.7
           - 3.8
           - 3.9


### PR DESCRIPTION
Remove python 3.6 from GitHub workflows. It seems to not be available anymore.