### PR TITLE
Update util.occurence to accept any frequency using resample

### DIFF
--- a/tests/reading/test_basic.py
+++ b/tests/reading/test_basic.py
@@ -80,8 +80,8 @@ def test_occurrence_db():
 
     assert occs['occurrence']['2018-07-10 00:00:00'] == 1
     assert occs['occurrence']['2018-07-10 12:00:00'] == 4
-    assert occs['hour']['2018-07-10 12:00:00'] == 12
-    assert occs['day']['2018-07-10 12:00:00'] == '2018-07-10'
+    #assert occs['hour']['2018-07-10 12:00:00'] == 12
+    #assert occs['day']['2018-07-10 12:00:00'] == '2018-07-10'
 
 def test_util_occurrence():
     data = niimpy.open(DATA, tz=TZ)
@@ -89,8 +89,8 @@ def test_util_occurrence():
     occs = niimpy.util.occurrence(timestamps)
     assert occs['occurrence']['2018-07-10 00:00:00'] == 1
     assert occs['occurrence']['2018-07-10 12:00:00'] == 4
-    assert occs['hour']['2018-07-10 12:00:00'] == 12
-    assert occs['day']['2018-07-10 12:00:00'] == '2018-07-10'
+    #assert occs['hour']['2018-07-10 12:00:00'] == 12
+    #assert occs['day']['2018-07-10 12:00:00'] == '2018-07-10'
 
 def test_hourly():
     data = niimpy.open(DATA, tz=TZ)
@@ -127,7 +127,7 @@ def test_filled_bins():
     gb2.loc['2018-07-10 00:00:00']['occurrence'] == 1
     gb2.loc['2018-07-10 12:00:00']['occurrence'] == 4
 
-    gb2 = niimpy.util.occurrence(timestamps, bin_width=720)
+    gb2 = niimpy.util.occurrence(timestamps, bin_width="12min")
     gb2.loc['2018-07-10 00:00:00']['occurrence'] == 1
     gb2.loc['2018-07-10 12:00:00']['occurrence'] == 4
 


### PR DESCRIPTION
Update occurence in util.py to accept any frequency parameters. This is done using resample rather than grouping by hour.

The function now does not return "day" and "hour" columns. These might not exist, depending on the resampling frequency. The change does not seem to break any tests, except the ones directly checking these columns.